### PR TITLE
Support enabling login hint in Caddyfile

### DIFF
--- a/assets/cla/consent.yaml
+++ b/assets/cla/consent.yaml
@@ -10,3 +10,5 @@
 #
 #- name: John Smith
 #  email: foo@bar.com
+- name: Lennart Schoch
+  email: lennartschoch@protonmail.com

--- a/caddyfile_authz_misc.go
+++ b/caddyfile_authz_misc.go
@@ -33,6 +33,18 @@ func parseCaddyfileAuthorizationMisc(h *caddyfile.Dispenser, repl *caddy.Replace
 			p.RedirectWithJavascript = true
 		case v == "strip token":
 			p.StripTokenEnabled = true
+		case strings.HasPrefix(v, "login hint"):
+			remainingArguments := strings.TrimPrefix(v, "login hint ")
+			switch {
+			case strings.HasPrefix(remainingArguments, "with"):
+				remainingArguments = strings.TrimPrefix(remainingArguments, "with ")
+				validationArguments := strings.Split(remainingArguments, " ")
+				p.LoginHintValidators = validationArguments
+				break
+			default:
+				p.LoginHintValidators = []string{"email", "phone", "alphanumeric"}
+				break
+			}
 		case v == "":
 			return h.Errf("%s directive has no value", rootDirective)
 		default:

--- a/caddyfile_authz_test.go
+++ b/caddyfile_authz_test.go
@@ -320,6 +320,50 @@ func TestParseCaddyfileAuthorization(t *testing.T) {
             }`,
 		},
 		{
+			name: "test valid authorization policy with enabled login hint",
+			d: caddyfile.NewTestDispenser(`
+            security {
+              authorization policy mypolicy {
+                enable login hint
+              }
+            }`),
+			want: `{
+              "config": {
+                "authz_policy_configs": [
+                  {
+                    "name": "mypolicy",
+                    "auth_url_path": "/auth",
+                    "auth_redirect_query_param": "redirect_url",
+                    "auth_redirect_status_code": 302,
+					"login_hint_validators": ["email", "phone", "alphanumeric"]
+                  }
+                ]
+              }
+            }`,
+		},
+		{
+			name: "test valid authorization policy with enabled login hint with validators",
+			d: caddyfile.NewTestDispenser(`
+            security {
+              authorization policy mypolicy {
+                enable login hint with email phone
+              }
+            }`),
+			want: `{
+              "config": {
+                "authz_policy_configs": [
+                  {
+                    "name": "mypolicy",
+                    "auth_url_path": "/auth",
+                    "auth_redirect_query_param": "redirect_url",
+                    "auth_redirect_status_code": 302,
+					"login_hint_validators": ["email", "phone"]
+                  }
+                ]
+              }
+            }`,
+		},
+		{
 			name: "test malformed authorization policy definition",
 			d: caddyfile.NewTestDispenser(`
             security {


### PR DESCRIPTION
This PR adds the `enable login hint` command, which depends on [another PR in go-authcrunch](https://github.com/greenpau/go-authcrunch/pull/2) that adds support for login hints. This PR is the second part of [this PR in caddy-authorize](https://github.com/greenpau/caddy-authorize/pull/95/files), migrated to the new repo structure.

I did not migrate the `disable login hint` command to this repo as primary/secondary instances do not seem to be present anymore.