### PR TITLE
if domain and insecure specified then set for prev

### DIFF
--- a/assets/cla/consent.yaml
+++ b/assets/cla/consent.yaml
@@ -16,3 +16,5 @@
   email: dbranco@gmail.com
 - name: Sergiu Cozma
   email: sergiucozma1994@gmail.com
+- name: Devin McCode
+  email: devinmccode@protonmail.com

--- a/caddyfile_authn_cookie.go
+++ b/caddyfile_authn_cookie.go
@@ -97,10 +97,12 @@ func updateAuthPortalCookieConfig(portal *authn.PortalConfig, domain, k, v strin
 		if err != nil {
 			return fmt.Errorf("%s value of %q is invalid: %v", k, v, err)
 		}
-		if defaultDomain {
-			portal.CookieConfig.Insecure = enabled
+		if len(portal.CookieConfig.Domains) > 0 {
+			for domainkey := range portal.CookieConfig.Domains {
+				portal.CookieConfig.Domains[domainkey].Insecure = enabled
+			}
 		} else {
-			portal.CookieConfig.Domains[domain].Insecure = enabled
+			portal.CookieConfig.Insecure = enabled
 		}
 	case "strip":
 		if v != "domain" {

--- a/caddyfile_authn_test.go
+++ b/caddyfile_authn_test.go
@@ -41,6 +41,7 @@ func TestParseCaddyfileAuthentication(t *testing.T) {
                 crypto default token lifetime 3600
                 crypto key sign-verify 01ee2688-36e4-47f9-8c06-d18483702520
 				cookie domain contoso.com
+				cookie insecure on
                 ui {
                   links {
                     "My Website" "/app" icon "las la-star"
@@ -166,7 +167,8 @@ func TestParseCaddyfileAuthentication(t *testing.T) {
 					  "domains": {
 						"contoso.com": {
 						  "seq": 1,
-						  "domain": "contoso.com"
+						  "domain": "contoso.com",
+						  "insecure": true
 						}
 					  }
 					},


### PR DESCRIPTION
What happened:

I was doing some local development and I specified both a `cookie domain x` and `cookie insecure on` in my Caddyfile. In this case, insecure was added to the default config, but the cookie writing logic checked the domain entry.
That logic is in another repo, `go-authcrunch`.

What I expected:

no `Secure; HttpOnly;` strings in cookies if the authentication block says`cookie insecure on`.

What the PR contains:

`updateAuthPortalCookieConfig` now checks to see if domains exist.  If so, insecure is added to those keys. If it is the  config writer's intent, they can have some domains use secure cookies by specifying them after the `cookie insecure on` line. The config test now includes `cookie insecure on`. No changes were needed to go-authcrunch because the struct lines up with the Caddyfile.