### PR TITLE
Add new field to CaddyFile field list

### DIFF
--- a/assets/cla/consent.yaml
+++ b/assets/cla/consent.yaml
@@ -5,6 +5,13 @@
 #  email: foo@bar.com
 #  company: Contoso Inc.
 #
+- name: Thomas Ottenhus
+  email: ottenhus@uni-mainz.de
+  company: Johannes Gutenberg University Mainz
+- name: Moritz Schlarb
+  email: schlarbm@uni-mainz.de
+  company: Johannes Gutenberg University Mainz
+
 # By adding your name and email below, you I hereby consent to the Individual
 # CLA provided in assets/cla/individual_cla.md.
 #

--- a/caddyfile_identity_provider.go
+++ b/caddyfile_identity_provider.go
@@ -50,6 +50,7 @@ import (
 //     enable logout
 //     extract <field1> <fieldN> from userinfo
 //     extract all from userinfo
+//     user_info_roles_field_name role
 //   }
 //
 //   oauth identity provider <name> {
@@ -101,7 +102,7 @@ func parseCaddyfileIdentityProvider(d *caddyfile.Dispenser, repl *caddy.Replacer
 			// OAuth
 			"domain_name", "client_id", "client_secret", "server_id", "base_auth_url",
 			"metadata_url", "identity_token_name", "authorization_url", "token_url",
-			"region", "user_pool_id",
+			"region", "user_pool_id", "user_info_roles_field_name",
 			// SAML
 			"idp_metadata_location", "idp_sign_cert_location", "idp_login_url",
 			"application_id", "application_name", "entity_id":


### PR DESCRIPTION
This builds on and fixes the initial approach from https://github.com/glatzert/go-authcrunch/commit/8de8c6b3551f74243df07c1f6d083a88974cbb14 to add a new configuration directive to specify the name of the "roles" claim.

Requires https://github.com/greenpau/go-authcrunch/pull/42